### PR TITLE
fix: don't reset dates when changing moving average

### DIFF
--- a/frontend/static/js/lib.js
+++ b/frontend/static/js/lib.js
@@ -243,6 +243,12 @@ window.onload = function () {
     const selected = Number(e.target.value);
     currentMovingAverage = selected
     let option = chartDefinition(processedData, currentMovingAverage)
+
+    // keep the start date the same as the current chart when the moving average is changed
+    let xAxisModel = chart.getModel().getComponent('xAxis', 0);
+    let xExtent = xAxisModel.axis.scale.getExtent();
+    let currentStartDate = xExtent[0];
+    option.dataZoom[0].startValue = currentStartDate
     chart.setOption(option);
   });
 


### PR DESCRIPTION
closes #56

![Peek 2025-04-30 16-23](https://github.com/user-attachments/assets/45c09e47-4960-446d-bdc9-40f4169295d6)
