### PR TITLE
fix: less white space on the right side of chart

### DIFF
--- a/frontend/static/js/charts/mining-hashrate-and-difficulty.js
+++ b/frontend/static/js/charts/mining-hashrate-and-difficulty.js
@@ -34,6 +34,10 @@ function chartDefinition(d, movingAverage) {
   y2 = zip(d.date, calcMovingAverage(d.y2, movingAverage, PRECISION))
   return {
     ...BASE_CHART_OPTION(START_DATE),
+    grid: {
+      left: "7%",
+      right: "7%",
+    },
     tooltip: { trigger: 'axis', valueFormatter: (v) => formatWithSIPrefix(v) },
     xAxis: { type: "time", data: d.date },
     yAxis: [

--- a/frontend/static/js/charts/payments-and-blocksize.js
+++ b/frontend/static/js/charts/payments-and-blocksize.js
@@ -29,6 +29,10 @@ function chartDefinition(d, movingAverage) {
   y2 = zip(d.date, calcMovingAverage(d.y2, movingAverage, PRECISION))
   return {
     ...BASE_CHART_OPTION(START_DATE),
+    grid: {
+      left: "7%",
+      right: "7%",
+    },
     xAxis: { type: "time", data: d.date },
     yAxis: [
       {

--- a/frontend/static/js/lib.js
+++ b/frontend/static/js/lib.js
@@ -66,7 +66,7 @@ const BASE_CHART_OPTION = (START_DATE) => {
   return {
     grid: {
       left: "7%",
-      right: "7%",
+      right: "0%",
     },
     graphic: watermark(watermarkText),
     legend: { },


### PR DESCRIPTION
Applies to all charts except the 2 double y-axis charts
- Payments and Blocksize
- Hashrate and Difficulty

closes #70 