### PR TITLE
change: always have a white chart background

### DIFF
--- a/frontend/static/js/lib.js
+++ b/frontend/static/js/lib.js
@@ -64,6 +64,7 @@ const tooltipPosition = function (pos, _params, _el, _elRect, size) {
 
 const BASE_CHART_OPTION = (START_DATE) => {
   return {
+    backgroundColor: 'white',
     grid: {
       left: "7%",
       right: "0%",


### PR DESCRIPTION
This is useful for the PNG exports. Can be made dynamic if/when darkmode is implemented.