### PR TITLE
add: dependabot updates for direct Rust depends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"


### PR DESCRIPTION
Dependabot will open PRs for direct Rust dependecies that need updating.