### PR TITLE
Add num-threads argument to allow threads to be limited by the user

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,7 +19,6 @@ env_logger = "0.11.3"
 clap = { version = "4.5.11", features = ["derive"] }
 bitcoin-pool-identification = "0.3.7"
 
-
 [dev-dependencies]
 corepc-node = { version = "0.6.1", features = ["28_0", "download"] }
 rand = "0.9.0"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use env_logger::Env;
-use log::error;
+use log::{error, info};
 use mainnet_observer_backend::{collect_statistics, db, write_csv_files, Args};
 use std::process::exit;
 use std::sync::{Arc, Mutex};
@@ -21,8 +21,18 @@ fn main() {
     };
     let conn = Arc::new(Mutex::new(conn));
 
+    info!(
+        "Using {} threads for block fetching & processing",
+        args.num_threads
+    );
+
     if !args.no_stats {
-        if let Err(e) = collect_statistics(&args.rest_host, args.rest_port, Arc::clone(&conn)) {
+        if let Err(e) = collect_statistics(
+            &args.rest_host,
+            args.rest_port,
+            Arc::clone(&conn),
+            args.num_threads,
+        ) {
             error!("Could not collect statistics: {}", e);
             exit(1);
         };

--- a/backend/tests/minimal.rs
+++ b/backend/tests/minimal.rs
@@ -85,7 +85,12 @@ fn test_integration_minimal() {
     setup_chain(&node, BLOCKS_TO_MINE as usize);
 
     let (rest_host, rest_port) = rest_host_and_port(&node);
-    if let Err(e) = collect_statistics(&rest_host, rest_port, Arc::clone(&conn)) {
+    if let Err(e) = collect_statistics(
+        &rest_host,
+        rest_port,
+        Arc::clone(&conn),
+        10, // Bitcoin Core v29 has 16, in the test use just use 10 of them.
+    ) {
         panic!("Failed to collect statistics: {:?}", e);
     }
 


### PR DESCRIPTION
This addresses https://github.com/0xB10C/mainnet-observer/issues/36

This PR introduces a new `--num-threads` command-line argument that allows users to configure
the number of threads used for fetching and processing Bitcoin blocks. This provides better
control over resource utilisation and helps prevent overwhelming the Bitcoin Core REST API. 
The default behaviour (14 threads) remains unchanged when `--num-threads` is not specified.

Changes:
- Added `--num-threads` optional CLI argument to specify the number of parallel fetch threads
- Set a default of 14 threads, leaving 2 threads available for Bitcoin Core's
default 16 HTTP request handlers
- ~Implemented validation to ensure the thread count doesn't exceed the maximum safe limit~

Usage Examples:
```
# Use default 14 threads
./mainnet-observer-backend

# Use only 8 threads for lower resource usage
./mainnet-observer-backend --num-threads 8

# Request 20 threads
./mainnet-observer-backend --num-threads 20
```

Testing:
- Verified the application respects the thread count limit
- Confirmed default behaviour is preserved when argument is omitted